### PR TITLE
Clangコンパイラを用いたときの実行時エラーの修復

### DIFF
--- a/cmake/CompileOptionSelector.cmake
+++ b/cmake/CompileOptionSelector.cmake
@@ -77,7 +77,7 @@ macro (AddOptimizeOption)
   elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3")
-    set(CMAKE_Fortran_FLAGS "-O3 -cpp")
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -O3 -cpp -Mfree")
 
   else()
     message("using default option")

--- a/cmake/CompileOptionSelector.cmake
+++ b/cmake/CompileOptionSelector.cmake
@@ -74,6 +74,11 @@ macro (AddOptimizeOption)
       set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -Mvect=simd:512")
     endif()
 
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3")
+    set(CMAKE_Fortran_FLAGS "-O3 -cpp")
+
   else()
     message("using default option")
   endif()
@@ -100,6 +105,9 @@ macro (FreeForm)
     set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -free")
 
   elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "PGI")
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -Mfree")
+
+  elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "Clang")
     set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -Mfree")
 
   endif()

--- a/src/cz_f90/cz_solver.f90
+++ b/src/cz_f90/cz_solver.f90
@@ -1060,23 +1060,15 @@ do j=jst, jed
 do i=ist, ied
 
 ! Reflesh coef. due to override
-do sq=0, s
-a(kst-s) = 0.0
-a(ked+s) = 0.0
-end do
-! override a(ked) = -r
+!a(kst) = 0.0
 do k=kst+1, ked
 a(k) = -r
 end do
 
-do sq=0, s
-c(kst-s) = 0.0
-c(ked+s) = 0.0
-end do
 do k=kst, ked-1
 c(k) = -r
 end do
-! over write c(kst)
+!c(ked) = 0.0
 
 ! Source
 !dir$ vector aligned

--- a/src/cz_f90/cz_solver.f90
+++ b/src/cz_f90/cz_solver.f90
@@ -1060,15 +1060,23 @@ do j=jst, jed
 do i=ist, ied
 
 ! Reflesh coef. due to override
-!a(kst) = 0.0
+do sq=0, s
+a(kst-sq) = 0.0
+a(ked+sq) = 0.0
+end do
+! override a(ked) = -r
 do k=kst+1, ked
 a(k) = -r
 end do
 
+do sq=0, s
+c(kst-sq) = 0.0
+c(ked+sq) = 0.0
+end do
 do k=kst, ked-1
 c(k) = -r
 end do
-!c(ked) = 0.0
+! over write c(kst)
 
 ! Source
 !dir$ vector aligned

--- a/src/cz_f90/cz_solver.f90
+++ b/src/cz_f90/cz_solver.f90
@@ -1060,15 +1060,23 @@ do j=jst, jed
 do i=ist, ied
 
 ! Reflesh coef. due to override
-!a(kst) = 0.0
+do sq=0, s
+a(kst-s) = 0.0
+a(ked+s) = 0.0
+end do
+! override a(ked) = -r
 do k=kst+1, ked
 a(k) = -r
 end do
 
+do sq=0, s
+c(kst-s) = 0.0
+c(ked+s) = 0.0
+end do
 do k=kst, ked-1
 c(k) = -r
 end do
-!c(ked) = 0.0
+! over write c(kst)
 
 ! Source
 !dir$ vector aligned


### PR DESCRIPTION
flang コンパイラのオプションに`-cpp -Mfree`を追加
